### PR TITLE
Standardize on using `nil` to represent an array nesting in scopes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,5 +48,9 @@ Style/TrailingCommaInArguments:
 Style/ClassAndModuleChildren:
   EnforcedStyle: nested
 
-Layout/MultilineOperationIndentation:
-  EnforcedStyle: indented
+# NOTE: Cop seems to be broken at the moment:
+#
+#   An error occurred while Layout/MultilineOperationIndentation cop was
+#   inspecting ./lib/rspec_api_docs/rake_task.rb:101:6
+# Layout/MultilineOperationIndentation:
+#   EnforcedStyle: indented

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ param :id, 'The id of a character', scope: :character, type: 'integer', required
 param :name, "The character's name", scope: :character, type: 'string'
 ```
 
-#### `notes`
+#### `note`
 
 Accepts a `note` and optional `level`.
 

--- a/lib/rspec_api_docs/formatter/resource/example/deep_hash_set.rb
+++ b/lib/rspec_api_docs/formatter/resource/example/deep_hash_set.rb
@@ -18,7 +18,7 @@ module RspecApiDocs
         def call
           keys.each_with_index do |key, index|
             case
-            when key.empty? # TODO: should this require `key == []`?
+            when key.nil?
               deep_set_value_at_array(index)
               break
             when index == keys.size - 1

--- a/lib/rspec_api_docs/version.rb
+++ b/lib/rspec_api_docs/version.rb
@@ -1,3 +1,3 @@
 module RspecApiDocs
-  VERSION = '0.11.0'
+  VERSION = '0.12.0'
 end

--- a/spec/rspec_api_docs/formatter/resource/example/deep_hash_set_spec.rb
+++ b/spec/rspec_api_docs/formatter/resource/example/deep_hash_set_spec.rb
@@ -41,7 +41,7 @@ module RspecApiDocs
           end
 
           context 'pointing at a hash within an array' do
-            let(:keys) { [:foo, :qux, [], :foo] }
+            let(:keys) { [:foo, :qux, nil, :foo] }
 
             it 'changes the value' do
               expect(call).to eq(
@@ -82,7 +82,7 @@ module RspecApiDocs
             end
 
             context 'changing a nested hash inside an array' do
-              let(:keys) { [:foo, :qux, [], :foo, :bar] }
+              let(:keys) { [:foo, :qux, nil, :foo, :bar] }
 
               it 'changes the value' do
                 expect(call).to eq(
@@ -110,7 +110,7 @@ module RspecApiDocs
             end
 
             context 'changing a hash inside an array inside a hash inside an array' do
-              let(:keys) { [:foo, :qux, [], :bar, [], :qux] }
+              let(:keys) { [:foo, :qux, nil, :bar, nil, :qux] }
 
               it 'changes the value' do
                 expect(call).to eq(


### PR DESCRIPTION
Given:

    {
      foo: [
        bar: 1,
      ],
    }

The scope for the `bar` key would be:

    [:foo, nil, :bar]
