### PR TITLE
Update Rubocop options to be compatible with latest Rubocop version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,7 +39,10 @@ Layout/SpaceInsideBlockBraces:
 Style/StringLiterals:
   EnforcedStyle: single_quotes
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
 Style/TrailingCommaInArguments:


### PR DESCRIPTION
Fixes 

```
Error: The `Style/TrailingCommaInLiteral` cop no longer exists. Please use `Style/TrailingCommaInArrayLiteral` and/or `Style/TrailingCommaInHashLiteral` instead.
(obsolete configuration found in .rubocop.yml, please update it)
RuboCop failed!
```

[Broken build](https://travis-ci.org/twe4ked/rspec-api-docs/builds/367005750?utm_source=github_status&utm_medium=notification) 