### PR TITLE
Revert "Rack::Test no longer sets a Content-Type for DELETE requests"

### DIFF
--- a/spec/integration/output/json/index.json
+++ b/spec/integration/output/json/index.json
@@ -114,7 +114,7 @@
             },
             "requestQueryParameters": {
             },
-            "requestContentType": null,
+            "requestContentType": "application/x-www-form-urlencoded",
             "responseStatus": 200,
             "responseStatusText": "OK",
             "responseBody": "{\"message\":\"Character not found.\"}",

--- a/spec/integration/output/raddocs/characters/deleting_a_character.json
+++ b/spec/integration/output/raddocs/characters/deleting_a_character.json
@@ -32,7 +32,7 @@
       },
       "request_query_parameters": {
       },
-      "request_content_type": null,
+      "request_content_type": "application/x-www-form-urlencoded",
       "response_status": 200,
       "response_status_text": "OK",
       "response_body": "{\"message\":\"Character not found.\"}",


### PR DESCRIPTION
This reverts commit adf56adb6b23e28c54f50517dea4b6c0deb14f12.

Because Rack::Test behaviour has now been reverted
https://github.com/rack-test/rack-test/pull/212