### PR TITLE
Include the request body in the generated JSON

### DIFF
--- a/lib/rspec_api_docs/formatter/resource/example.rb
+++ b/lib/rspec_api_docs/formatter/resource/example.rb
@@ -126,6 +126,7 @@ module RspecApiDocs
       end
 
       def request_body(body)
+	body.rewind if body.respond_to?(:rewind)
         body = body.read
         body.empty? ? nil : body
       end

--- a/lib/rspec_api_docs/formatter/resource/example.rb
+++ b/lib/rspec_api_docs/formatter/resource/example.rb
@@ -126,7 +126,7 @@ module RspecApiDocs
       end
 
       def request_body(body)
-	body.rewind if body.respond_to?(:rewind)
+        body.rewind if body.respond_to?(:rewind)
         body = body.read
         body.empty? ? nil : body
       end


### PR DESCRIPTION
The `request_body(body)` method currently passes in a `body` variable which is a `Rack::Lint::InputWrapper` which just wraps `StringIO`.

By the time it reaches this method the body has already been read and the position of the reader is always at the end of the string so `requestBody` always outputs `nil` in the generated JSON.

This PR just rewinds the position so that the request body can be included in the output JSON