### PR TITLE
return nil for non-JSON response bodies rather than blowing up

### DIFF
--- a/spec/rspec_api_docs/formatter/resource/example_spec.rb
+++ b/spec/rspec_api_docs/formatter/resource/example_spec.rb
@@ -194,6 +194,49 @@ module RspecApiDocs
           ]
         end
 
+        context 'when the response does not contain JSON' do
+
+          let(:last_response_2) do
+            double(:last_response,
+              status: 200,
+              body: 'BINARY PDF DATA',
+              headers: {},
+              content_type: 'application/pdf',
+            )
+          end
+
+          it 'returns requests but excludes the PDF body' do
+            expect(subject.requests).to eq [
+              {
+                request_method: 'POST',
+                request_path: '/characters',
+                request_body: nil,
+                request_headers: {},
+                request_query_parameters: {},
+                request_content_type: 'application/json',
+                response_status: 201,
+                response_status_text: 'Created',
+                response_body: '{"character":{"id":1,"name":"Earl of Lemongrab"}}',
+                response_headers: {},
+                response_content_type: 'application/json',
+              },
+              {
+                request_method: 'GET',
+                request_path: '/characters/1',
+                request_body: nil,
+                request_headers: {},
+                request_query_parameters: {},
+                request_content_type: 'application/json',
+                response_status: 200,
+                response_status_text: 'OK',
+                response_body: nil,
+                response_headers: {},
+                response_content_type: 'application/pdf',
+              },
+            ]
+          end
+        end
+
         context 'with excluded response headers' do
           let(:_metadata) do
             {


### PR DESCRIPTION
I'm currently trying to add API documentation for an endpoint that returns a PDF in the response body but it's blowing up while trying to generate the documentation because the `response_body` method always assumes that the response is JSON.

This PR changes the behaviour to only include a JSON response body when a response content type is `application/json`, every thing else will return `nil`.

