### PR TITLE
Only include JSON response body when the response content_type is 'application/json'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - This CHANGELOG file.
 
 ### Changed
-- Include the request body in the generated JSON [#9] ([@2potatocakes])
+- The JSON response body will only be documented when the content type is `application/json` [#9] ([@2potatocakes])
 
 [Unreleased]: https://github.com/twe4ked/rspec-api-docs/compare/v0.14.0...HEAD
 [0.14.0]: https://github.com/twe4ked/rspec-api-docs/compare/v0.13.0...v0.14.0

--- a/spec/integration/output/json/index.json
+++ b/spec/integration/output/json/index.json
@@ -27,13 +27,11 @@
             "responseStatusText": "OK",
             "responseBody": "{\"data\":[{\"id\":1,\"name\":\"Finn the Human\"},{\"id\":2,\"name\":\"Jake the Dog\"}]}",
             "responseHeaders": {
-              "Content-Type": "text/html;charset=utf-8",
+              "Content-Type": "application/json",
               "Content-Length": "74",
-              "X-XSS-Protection": "1; mode=block",
-              "X-Content-Type-Options": "nosniff",
-              "X-Frame-Options": "SAMEORIGIN"
+              "X-Content-Type-Options": "nosniff"
             },
-            "responseContentType": "text/html;charset=utf-8"
+            "responseContentType": "application/json"
           }
         ],
         "responseFields": [
@@ -75,13 +73,11 @@
             "responseStatusText": "OK",
             "responseBody": null,
             "responseHeaders": {
-              "Content-Type": "text/html;charset=utf-8",
+              "Content-Type": "application/json",
               "Content-Length": "74",
-              "X-XSS-Protection": "1; mode=block",
-              "X-Content-Type-Options": "nosniff",
-              "X-Frame-Options": "SAMEORIGIN"
+              "X-Content-Type-Options": "nosniff"
             },
-            "responseContentType": "text/html;charset=utf-8"
+            "responseContentType": "application/json"
           }
         ],
         "responseFields": [
@@ -119,13 +115,11 @@
             "responseStatusText": "OK",
             "responseBody": "{\"message\":\"Character not found.\"}",
             "responseHeaders": {
-              "Content-Type": "text/html;charset=utf-8",
+              "Content-Type": "application/json",
               "Content-Length": "34",
-              "X-XSS-Protection": "1; mode=block",
-              "X-Content-Type-Options": "nosniff",
-              "X-Frame-Options": "SAMEORIGIN"
+              "X-Content-Type-Options": "nosniff"
             },
-            "responseContentType": "text/html;charset=utf-8"
+            "responseContentType": "application/json"
           }
         ],
         "responseFields": [
@@ -166,13 +160,11 @@
             "responseStatusText": "OK",
             "responseBody": "{\"character\":{\"id\":42,\"name\":\"Finn the Human\"}}",
             "responseHeaders": {
-              "Content-Type": "text/html;charset=utf-8",
+              "Content-Type": "application/json",
               "Content-Length": "47",
-              "X-XSS-Protection": "1; mode=block",
-              "X-Content-Type-Options": "nosniff",
-              "X-Frame-Options": "SAMEORIGIN"
+              "X-Content-Type-Options": "nosniff"
             },
-            "responseContentType": "text/html;charset=utf-8"
+            "responseContentType": "application/json"
           }
         ],
         "responseFields": [
@@ -216,13 +208,11 @@
             "responseStatusText": "Not Found",
             "responseBody": "{\"errors\":{\"message\":\"Character not found.\"}}",
             "responseHeaders": {
-              "Content-Type": "text/html;charset=utf-8",
+              "Content-Type": "application/json",
               "Content-Length": "45",
-              "X-XSS-Protection": "1; mode=block",
-              "X-Content-Type-Options": "nosniff",
-              "X-Frame-Options": "SAMEORIGIN"
+              "X-Content-Type-Options": "nosniff"
             },
-            "responseContentType": "text/html;charset=utf-8"
+            "responseContentType": "application/json"
           }
         ],
         "responseFields": [
@@ -270,13 +260,11 @@
             "responseStatusText": "OK",
             "responseBody": "{\"data\":[{\"id\":1,\"name\":\"Candy Kingdom\"},{\"id\":2,\"name\":\"Tree Fort\"}]}",
             "responseHeaders": {
-              "Content-Type": "text/html;charset=utf-8",
+              "Content-Type": "application/json",
               "Content-Length": "70",
-              "X-XSS-Protection": "1; mode=block",
-              "X-Content-Type-Options": "nosniff",
-              "X-Frame-Options": "SAMEORIGIN"
+              "X-Content-Type-Options": "nosniff"
             },
-            "responseContentType": "text/html;charset=utf-8"
+            "responseContentType": "application/json"
           },
           {
             "requestMethod": "GET",
@@ -294,13 +282,11 @@
             "responseStatusText": "OK",
             "responseBody": "{\"data\":[]}",
             "responseHeaders": {
-              "Content-Type": "text/html;charset=utf-8",
+              "Content-Type": "application/json",
               "Content-Length": "11",
-              "X-XSS-Protection": "1; mode=block",
-              "X-Content-Type-Options": "nosniff",
-              "X-Frame-Options": "SAMEORIGIN"
+              "X-Content-Type-Options": "nosniff"
             },
-            "responseContentType": "text/html;charset=utf-8"
+            "responseContentType": "application/json"
           }
         ],
         "responseFields": [
@@ -343,13 +329,11 @@
             "responseStatusText": "OK",
             "responseBody": "{\"data\":[{\"id\":1,\"name\":\"Candy Kingdom\"},{\"id\":2,\"name\":\"Tree Fort\"}]}",
             "responseHeaders": {
-              "Content-Type": "text/html;charset=utf-8",
+              "Content-Type": "application/json",
               "Content-Length": "70",
-              "X-XSS-Protection": "1; mode=block",
-              "X-Content-Type-Options": "nosniff",
-              "X-Frame-Options": "SAMEORIGIN"
+              "X-Content-Type-Options": "nosniff"
             },
-            "responseContentType": "text/html;charset=utf-8"
+            "responseContentType": "application/json"
           }
         ],
         "responseFields": [
@@ -391,13 +375,11 @@
             "responseStatusText": "OK",
             "responseBody": "{\"data\":[{\"id\":2,\"name\":\"Tree Fort\"}]}",
             "responseHeaders": {
-              "Content-Type": "text/html;charset=utf-8",
+              "Content-Type": "application/json",
               "Content-Length": "70",
-              "X-XSS-Protection": "1; mode=block",
-              "X-Content-Type-Options": "nosniff",
-              "X-Frame-Options": "SAMEORIGIN"
+              "X-Content-Type-Options": "nosniff"
             },
-            "responseContentType": "text/html;charset=utf-8"
+            "responseContentType": "application/json"
           }
         ],
         "responseFields": [

--- a/spec/integration/output/raddocs/characters/characters_head.json
+++ b/spec/integration/output/raddocs/characters/characters_head.json
@@ -27,13 +27,11 @@
       "response_status_text": "OK",
       "response_body": null,
       "response_headers": {
-        "Content-Type": "text/html;charset=utf-8",
+        "Content-Type": "application/json",
         "Content-Length": "74",
-        "X-XSS-Protection": "1; mode=block",
-        "X-Content-Type-Options": "nosniff",
-        "X-Frame-Options": "SAMEORIGIN"
+        "X-Content-Type-Options": "nosniff"
       },
-      "response_content_type": "text/html;charset=utf-8",
+      "response_content_type": "application/json",
       "curl": null
     }
   ]

--- a/spec/integration/output/raddocs/characters/deleting_a_character.json
+++ b/spec/integration/output/raddocs/characters/deleting_a_character.json
@@ -37,13 +37,11 @@
       "response_status_text": "OK",
       "response_body": "{\"message\":\"Character not found.\"}",
       "response_headers": {
-        "Content-Type": "text/html;charset=utf-8",
+        "Content-Type": "application/json",
         "Content-Length": "34",
-        "X-XSS-Protection": "1; mode=block",
-        "X-Content-Type-Options": "nosniff",
-        "X-Frame-Options": "SAMEORIGIN"
+        "X-Content-Type-Options": "nosniff"
       },
-      "response_content_type": "text/html;charset=utf-8",
+      "response_content_type": "application/json",
       "curl": null
     }
   ]

--- a/spec/integration/output/raddocs/characters/fetching_a_character.json
+++ b/spec/integration/output/raddocs/characters/fetching_a_character.json
@@ -43,13 +43,11 @@
       "response_status_text": "OK",
       "response_body": "{\"character\":{\"id\":42,\"name\":\"Finn the Human\"}}",
       "response_headers": {
-        "Content-Type": "text/html;charset=utf-8",
+        "Content-Type": "application/json",
         "Content-Length": "47",
-        "X-XSS-Protection": "1; mode=block",
-        "X-Content-Type-Options": "nosniff",
-        "X-Frame-Options": "SAMEORIGIN"
+        "X-Content-Type-Options": "nosniff"
       },
-      "response_content_type": "text/html;charset=utf-8",
+      "response_content_type": "application/json",
       "curl": null
     }
   ]

--- a/spec/integration/output/raddocs/characters/listing_all_characters.json
+++ b/spec/integration/output/raddocs/characters/listing_all_characters.json
@@ -38,13 +38,11 @@
       "response_status_text": "OK",
       "response_body": "{\"data\":[{\"id\":1,\"name\":\"Finn the Human\"},{\"id\":2,\"name\":\"Jake the Dog\"}]}",
       "response_headers": {
-        "Content-Type": "text/html;charset=utf-8",
+        "Content-Type": "application/json",
         "Content-Length": "74",
-        "X-XSS-Protection": "1; mode=block",
-        "X-Content-Type-Options": "nosniff",
-        "X-Frame-Options": "SAMEORIGIN"
+        "X-Content-Type-Options": "nosniff"
       },
-      "response_content_type": "text/html;charset=utf-8",
+      "response_content_type": "application/json",
       "curl": null
     }
   ]

--- a/spec/integration/output/raddocs/characters/when_a_character_cannot_be_found.json
+++ b/spec/integration/output/raddocs/characters/when_a_character_cannot_be_found.json
@@ -32,13 +32,11 @@
       "response_status_text": "Not Found",
       "response_body": "{\"errors\":{\"message\":\"Character not found.\"}}",
       "response_headers": {
-        "Content-Type": "text/html;charset=utf-8",
+        "Content-Type": "application/json",
         "Content-Length": "45",
-        "X-XSS-Protection": "1; mode=block",
-        "X-Content-Type-Options": "nosniff",
-        "X-Frame-Options": "SAMEORIGIN"
+        "X-Content-Type-Options": "nosniff"
       },
-      "response_content_type": "text/html;charset=utf-8",
+      "response_content_type": "application/json",
       "curl": null
     }
   ]

--- a/spec/integration/output/raddocs/places/fetching_all_places_and_page__.json
+++ b/spec/integration/output/raddocs/places/fetching_all_places_and_page__.json
@@ -42,13 +42,11 @@
       "response_status_text": "OK",
       "response_body": "{\"data\":[{\"id\":1,\"name\":\"Candy Kingdom\"},{\"id\":2,\"name\":\"Tree Fort\"}]}",
       "response_headers": {
-        "Content-Type": "text/html;charset=utf-8",
+        "Content-Type": "application/json",
         "Content-Length": "70",
-        "X-XSS-Protection": "1; mode=block",
-        "X-Content-Type-Options": "nosniff",
-        "X-Frame-Options": "SAMEORIGIN"
+        "X-Content-Type-Options": "nosniff"
       },
-      "response_content_type": "text/html;charset=utf-8",
+      "response_content_type": "application/json",
       "curl": null
     },
     {
@@ -67,13 +65,11 @@
       "response_status_text": "OK",
       "response_body": "{\"data\":[]}",
       "response_headers": {
-        "Content-Type": "text/html;charset=utf-8",
+        "Content-Type": "application/json",
         "Content-Length": "11",
-        "X-XSS-Protection": "1; mode=block",
-        "X-Content-Type-Options": "nosniff",
-        "X-Frame-Options": "SAMEORIGIN"
+        "X-Content-Type-Options": "nosniff"
       },
-      "response_content_type": "text/html;charset=utf-8",
+      "response_content_type": "application/json",
       "curl": null
     }
   ]

--- a/spec/integration/output/raddocs/places/listing_all_places.json
+++ b/spec/integration/output/raddocs/places/listing_all_places.json
@@ -38,13 +38,11 @@
       "response_status_text": "OK",
       "response_body": "{\"data\":[{\"id\":1,\"name\":\"Candy Kingdom\"},{\"id\":2,\"name\":\"Tree Fort\"}]}",
       "response_headers": {
-        "Content-Type": "text/html;charset=utf-8",
+        "Content-Type": "application/json",
         "Content-Length": "70",
-        "X-XSS-Protection": "1; mode=block",
-        "X-Content-Type-Options": "nosniff",
-        "X-Frame-Options": "SAMEORIGIN"
+        "X-Content-Type-Options": "nosniff"
       },
-      "response_content_type": "text/html;charset=utf-8",
+      "response_content_type": "application/json",
       "curl": null
     }
   ]

--- a/spec/integration/output/raddocs/places/listing_all_places_with_a_modified_response_bod_.json
+++ b/spec/integration/output/raddocs/places/listing_all_places_with_a_modified_response_bod_.json
@@ -38,13 +38,11 @@
       "response_status_text": "OK",
       "response_body": "{\"data\":[{\"id\":2,\"name\":\"Tree Fort\"}]}",
       "response_headers": {
-        "Content-Type": "text/html;charset=utf-8",
+        "Content-Type": "application/json",
         "Content-Length": "70",
-        "X-XSS-Protection": "1; mode=block",
-        "X-Content-Type-Options": "nosniff",
-        "X-Frame-Options": "SAMEORIGIN"
+        "X-Content-Type-Options": "nosniff"
       },
-      "response_content_type": "text/html;charset=utf-8",
+      "response_content_type": "application/json",
       "curl": null
     }
   ]

--- a/spec/integration/rspec_api_docs_spec.rb
+++ b/spec/integration/rspec_api_docs_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe RspecApiDocs do
       2 => {name: 'Tree Fort'},
     }
 
+    before do
+      content_type 'application/json'
+    end
+
     get '/characters' do
       characters = CHARACTERS.map { |id, character| {id: id}.merge(character) }
 

--- a/spec/rspec_api_docs/formatter/resource/example_spec.rb
+++ b/spec/rspec_api_docs/formatter/resource/example_spec.rb
@@ -200,10 +200,46 @@ module RspecApiDocs
           ]
         end
 
-        it 'rewinds the request body' do
-          subject.requests
+        context 'when the response does not contain JSON' do
+          let(:last_response_2) do
+            double(:last_response,
+              status: 200,
+              body: 'BINARY PDF DATA',
+              headers: {},
+              content_type: 'application/pdf',
+            )
+          end
 
-          expect(request_1_body.pos).to eq 0
+          it 'returns requests but excludes the PDF body' do
+            expect(subject.requests).to eq [
+              {
+                request_method: 'POST',
+                request_path: '/characters',
+                request_body: '{"character":{"name":"Earl of Lemongrab"}}',
+                request_headers: {},
+                request_query_parameters: {},
+                request_content_type: 'application/json',
+                response_status: 201,
+                response_status_text: 'Created',
+                response_body: '{"character":{"id":1,"name":"Earl of Lemongrab"}}',
+                response_headers: {},
+                response_content_type: 'application/json',
+              },
+              {
+                request_method: 'GET',
+                request_path: '/characters/1',
+                request_body: nil,
+                request_headers: {},
+                request_query_parameters: {},
+                request_content_type: 'application/json',
+                response_status: 200,
+                response_status_text: 'OK',
+                response_body: nil,
+                response_headers: {},
+                response_content_type: 'application/pdf',
+              },
+            ]
+          end
         end
 
         context 'with excluded response headers' do


### PR DESCRIPTION
I'm currently trying to add API documentation for an endpoint that returns a PDF in the response body but it's blowing up while trying to generate the documentation because the `response_body` method always assumes that the response is JSON.

This PR changes the behaviour to only include a JSON response body when a response content type is `application/json`, every thing else will return `nil`.

