### PR TITLE
Allow various different variations of a json mime type

### DIFF
--- a/lib/rspec_api_docs/formatter/resource/example.rb
+++ b/lib/rspec_api_docs/formatter/resource/example.rb
@@ -133,7 +133,7 @@ module RspecApiDocs
       end
 
       def response_body(body, content_type:)
-        unless body.empty? || content_type != 'application/json'
+        unless body.empty? || !content_type.to_s.include?('json')
           parsed_body = JSON.parse(body, symbolize_names: true)
           response_fields.each do |f|
             unless f.example.nil?

--- a/spec/rspec_api_docs/formatter/resource/example_spec.rb
+++ b/spec/rspec_api_docs/formatter/resource/example_spec.rb
@@ -145,7 +145,7 @@ module RspecApiDocs
             status: 201,
             body: JSON.dump(character: {id: 1, name: 'Earl of Lemongrab'}),
             headers: last_response_1_headers,
-            content_type: 'application/json',
+            content_type: 'application/vnd.api+json; charset=utf-8',
           )
         end
 
@@ -182,7 +182,7 @@ module RspecApiDocs
               response_status_text: 'Created',
               response_body: '{"character":{"id":1,"name":"Earl of Lemongrab"}}',
               response_headers: {},
-              response_content_type: 'application/json',
+              response_content_type: 'application/vnd.api+json; charset=utf-8',
             },
             {
               request_method: 'GET',


### PR DESCRIPTION
This PR relaxes the content_type check to allow any content type that includes the term `json`

This allows the response body to be captured properly when the API specifies a different variation of a json mime type.